### PR TITLE
feat: admin improvements

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -1,3 +1,14 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 process.env.MAGIC_LINK_API_KEY = 'test-api-key';
 process.env.API_GATEWAY_URL = 'https://example.com';
 process.env.CHANNEL_MAPPING_URL = 'https://example.com';

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -117,7 +117,7 @@ async function handleJoinMessage(message, context) {
   const { teamId, channelName } = await getChannelInfo(channel);
 
   console.debug('posting to admin channel...');
-  await postToAdminChannel(`User ${email} joined channel <a href="#${channelName}">#${channelName}</a>`);
+  await postToAdminChannel(`User ${email} joined channel <#${channel}>`);
 
   return {
     email,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -113,11 +113,11 @@ async function handleJoinMessage(message, context) {
     email,
   });
 
-  console.debug('posting to admin channel...');
-  await postToAdminChannel(`User ${email} joined channel ${channel}`);
-
   console.debug('getting channel info...');
   const { teamId, channelName } = await getChannelInfo(channel);
+
+  console.debug('posting to admin channel...');
+  await postToAdminChannel(`User ${email} joined channel #${channelName} / ${channel}`);
 
   return {
     email,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -113,11 +113,11 @@ async function handleJoinMessage(message, context) {
     email,
   });
 
-  console.debug('getting channel info...');
-  const { teamId, channelName } = await getChannelInfo(channel);
-
   console.debug('posting to admin channel...');
   await postToAdminChannel(`User ${email} joined channel <#${channel}>`);
+
+  console.debug('getting channel info...');
+  const { teamId, channelName } = await getChannelInfo(channel);
 
   return {
     email,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -117,7 +117,7 @@ async function handleJoinMessage(message, context) {
   const { teamId, channelName } = await getChannelInfo(channel);
 
   console.debug('posting to admin channel...');
-  await postToAdminChannel(`User ${email} joined channel #${channelName} / ${channel}`);
+  await postToAdminChannel(`User ${email} joined channel <a href="#${channelName}">#${channelName}</a>`);
 
   return {
     email,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -91,11 +91,20 @@ async function handleDisconnect(connectionId) {
 async function handleJoinMessage(message, context) {
   const { connectionId, email } = context;
 
-  const domain = getEmailDomain(email);
   const channels = await getChannels();
 
-  console.debug(`getting channel by domain: ${domain}`);
-  const channel = channels.get(domain);
+  // check for admin access: set email address in mapping list
+  console.debug(`direct access - getting channel by full email: ${email}`);
+  let channel = channels.get(email);
+
+  if (channel) {
+    console.debug(`found direct access: ${email} -> ${channel}`);
+  } else {
+    const domain = getEmailDomain(email);
+    console.debug(`getting channel by domain: ${domain}`);
+    channel = channels.get(domain);
+  }
+
   if (!channel) {
     console.error(`no channel mapping found for ${email}`);
     await postToAdminChannel(`No channel mapping found for ${email}`);


### PR DESCRIPTION
- in admin channel, adds a link to the channel in user connected message.
- allow to specify an email address in the channel mapping: specific user is then bound to a specific channel. This has prio. Useful for "impersonating", connecting to a specific channel and see what the customer sees.