### PR TITLE
fix: do not disconnect if no mapping found

### DIFF
--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -110,8 +110,8 @@ async function handleJoinMessage(message, context) {
     console.error(`no channel mapping found for ${email}`);
     await postToAdminChannel(`No channel mapping found for ${email}`);
 
-    console.debug('disconnecting client');
-    await deleteConnection(connectionId);
+    // console.debug('disconnecting client');
+    // await deleteConnection(connectionId);
 
     throw new Error(403);
   }

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -110,9 +110,6 @@ async function handleJoinMessage(message, context) {
     console.error(`no channel mapping found for ${email}`);
     await postToAdminChannel(`No channel mapping found for ${email}`);
 
-    // console.debug('disconnecting client');
-    // await deleteConnection(connectionId);
-
     throw new Error(403);
   }
 
@@ -205,17 +202,14 @@ async function handleMessage(event) {
         error = 'Not authorized';
       }
     } catch (er) {
-      // use exception message as error message
-      console.error('error while parsing code', er.message, er);
+      // ignore, use exception message as error message
     }
 
     console.error(`responding with code: ${code} and error: ${error}`);
     return {
       body: JSON.stringify({
-        data: {
-          error,
-          code,
-        },
+        error,
+        code,
         correlationId: message.correlationId,
       }),
       statusCode: 200,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -208,8 +208,10 @@ async function handleMessage(event) {
     console.error(`responding with code: ${code} and error: ${error}`);
     return {
       body: JSON.stringify({
-        error,
-        code,
+        data: {
+          error,
+          code,
+        },
         correlationId: message.correlationId,
       }),
       statusCode: 200,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -211,9 +211,10 @@ async function handleMessage(event) {
     return {
       body: JSON.stringify({
         error,
+        code,
         correlationId: message.correlationId,
       }),
-      statusCode: code,
+      statusCode: 200,
     };
   }
 }

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -192,11 +192,11 @@ async function handleMessage(event) {
       statusCode: 200,
     };
   } catch (e) {
-    console.error('error while processing message', e);
+    console.error('error while processing message', e.message, e);
     let error = e.message;
     let code = 500;
     try {
-      code = parseInt(e.message, 10);
+      code = parseInt(error, 10);
       if (code === 400) {
         error = `Unknow message type: ${message.type}`;
       } else if (code === 403) {
@@ -206,8 +206,10 @@ async function handleMessage(event) {
       }
     } catch (er) {
       // use exception message as error message
+      console.error('error while parsing code', er.message, er);
     }
 
+    console.error(`responding with code: ${code} and error: ${error}`);
     return {
       body: JSON.stringify({
         data: {

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -110,7 +110,7 @@ async function handleJoinMessage(message, context) {
     console.error(`no channel mapping found for ${email}`);
     await postToAdminChannel(`No channel mapping found for ${email}`);
 
-    throw new Error(403);
+    throw new Error('No channel mapping found');
   }
 
   console.debug('storing connection details...');
@@ -165,7 +165,7 @@ async function processMessage(type, data, context) {
     case 'replies':
       return handleRepliesMessage(data, context);
     default:
-      throw new Error(400);
+      throw new Error(`Unknown message type: ${type}`);
   }
 }
 
@@ -189,33 +189,15 @@ async function handleMessage(event) {
       statusCode: 200,
     };
   } catch (e) {
-    console.error('error while processing message', e.message, e);
-    let error = e.message;
-    let code = 500;
-    try {
-      code = parseInt(error, 10);
-      if (code === 400) {
-        error = `Unknow message type: ${message.type}`;
-      } else if (code === 403) {
-        error = 'Forbidden';
-      } else if (code === 401) {
-        error = 'Not authorized';
-      }
-    } catch (er) {
-      // ignore, use exception message as error message
-    }
+    console.error('error while processing message', e);
 
-    console.error(`responding with code: ${code} and error: ${error}`);
     return {
       body: JSON.stringify({
-        data: {
-          error,
-          code,
-        },
+        error: e.message,
         correlationId: message.correlationId,
       }),
       statusCode: 200,
-    };
+    }
   }
 }
 

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -210,8 +210,10 @@ async function handleMessage(event) {
 
     return {
       body: JSON.stringify({
-        error,
-        code,
+        data: {
+          error,
+          code,
+        },
         correlationId: message.correlationId,
       }),
       statusCode: 200,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -190,7 +190,6 @@ async function handleMessage(event) {
     };
   } catch (e) {
     console.error('error while processing message', e);
-
     return {
       body: JSON.stringify({
         error: e.message,

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -197,7 +197,7 @@ async function handleMessage(event) {
         correlationId: message.correlationId,
       }),
       statusCode: 200,
-    }
+    };
   }
 }
 

--- a/src/ChatEventHandler.js
+++ b/src/ChatEventHandler.js
@@ -207,7 +207,7 @@ async function handleMessage(event) {
     } catch (er) {
       // use exception message as error message
     }
-    
+
     return {
       body: JSON.stringify({
         error,


### PR DESCRIPTION
If disconnection happens, client will instantly try to re-connect thus we need another mechanism to inform client is not allowed. More generally, error handling must happen via messages (i.e. 200 messages containing error code + message) and client has to deal with it. We need to keep the connect / disconnect state for the "network" layer.